### PR TITLE
Make 'Sync' trait required for 'ssstar::SourceArchive::Reader(..)'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixes
+## 0.4.0 - 27-Jan-2023
 
 ### Breaking Changes
+
+* Add `Sync` trait requirement to the inner reader of `ssstar::SourceArchive::Reader(..)`.  Now, the inner reader
+  requires implementation of traits: `Read + Send + Sync`
 
 ### Dependencies
 

--- a/ssstar/src/async_bridge.rs
+++ b/ssstar/src/async_bridge.rs
@@ -19,7 +19,7 @@ use tokio::io::AsyncWrite;
 /// performed in a blocking worker thread, using [`tokio::task::spawn_blocking`].
 pub(crate) fn stream_as_reader<S>(stream: S) -> impl Read
 where
-    S: Stream<Item = Result<Bytes>> + Send + 'static,
+    S: Stream<Item = Result<Bytes>> + Send + Sync + 'static,
 {
     let handle = tokio::runtime::Handle::current();
 
@@ -48,7 +48,7 @@ where
 
 struct TryStreamReader {
     buffer: Option<Reader<Bytes>>,
-    stream: Pin<Box<dyn Stream<Item = Result<Bytes>> + Send>>,
+    stream: Pin<Box<dyn Stream<Item = Result<Bytes>> + Send + Sync>>,
     handle: tokio::runtime::Handle,
 }
 


### PR DESCRIPTION
It's required to be able to move the 'ssstar::ExtractArchiveJobBuilder'
into a future like `async move { .. }` and store this future in a struct
