### PR TITLE
Add 'aws_session_token' to 'Config'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.4.1 - 16-Feb-2023
+
+* Add `aws_session_token` option for `ssstar::Config` to allow to use AWS temporal credentials
+
 ## 0.4.0 - 27-Jan-2023
 
 ### Breaking Changes

--- a/ssstar/src/config.rs
+++ b/ssstar/src/config.rs
@@ -40,6 +40,15 @@ pub struct Config {
     )]
     pub aws_secret_access_key: Option<String>,
 
+    /// Sets a session token
+    ///
+    /// This is required if you use temporally credentials
+    #[cfg_attr(
+        feature = "clap",
+        clap(long, global = true, requires = "aws_secret_access_key")
+    )]
+    pub aws_session_token: Option<String>,
+
     /// Use a custom S3 endpoint instead of AWS.
     ///
     /// Use this to operate on a non-Amazon S3-compatible service.  If this is set, the AWS region
@@ -93,6 +102,7 @@ impl Default for Config {
             aws_region: None,
             aws_access_key_id: None,
             aws_secret_access_key: None,
+            aws_session_token: None,
             s3_endpoint: None,
             multipart_chunk_size: byte_unit::Byte::from_bytes(8 * 1024 * 1024),
             multipart_threshold: byte_unit::Byte::from_bytes(8 * 1024 * 1024),

--- a/ssstar/src/config.rs
+++ b/ssstar/src/config.rs
@@ -40,9 +40,9 @@ pub struct Config {
     )]
     pub aws_secret_access_key: Option<String>,
 
-    /// Sets a session token
+    /// Sets AWS session token for AWS operations
     ///
-    /// This is required if you use temporally credentials
+    /// This is required if you use temporal credentials
     #[cfg_attr(
         feature = "clap",
         clap(long, global = true, requires = "aws_secret_access_key")

--- a/ssstar/src/objstore/s3.rs
+++ b/ssstar/src/objstore/s3.rs
@@ -1457,7 +1457,7 @@ async fn make_s3_client(
         aws_config_builder = aws_config_builder.credentials_provider(Credentials::from_keys(
             aws_access_key_id,
             aws_secret_access_key,
-            None,
+            config.aws_session_token.clone(),
         ));
     }
 


### PR DESCRIPTION
The new option `aws_session_token` is added to `ssstar::Config`.
It is needed to be able to use AWS temporal credentials with `ssstar`