### PR TITLE
Add User Agent config option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,7 +2300,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "ssstar"
-version = "0.4.2"
+version = "0.4.3-dev"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2340,7 +2340,7 @@ dependencies = [
 
 [[package]]
 name = "ssstar-cli"
-version = "0.4.2"
+version = "0.4.3-dev"
 dependencies = [
  "byte-unit",
  "clap",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "ssstar-testing"
-version = "0.4.2"
+version = "0.4.3-dev"
 dependencies = [
  "again",
  "aws-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,7 +2300,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "ssstar"
-version = "0.4.2-dev"
+version = "0.4.2"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2340,7 +2340,7 @@ dependencies = [
 
 [[package]]
 name = "ssstar-cli"
-version = "0.4.2-dev"
+version = "0.4.2"
 dependencies = [
  "byte-unit",
  "clap",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "ssstar-testing"
-version = "0.4.2-dev"
+version = "0.4.2"
 dependencies = [
  "again",
  "aws-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e8615bf58d144dec3fcdb5110941b84e904c68054cb74ed240b9588fc337a5"
+checksum = "63c712a28a4f2f2139759235c08bf98aca99d4fdf1b13c78c5f95613df0a5db9"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-client"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c1df4c1d03e1ce299ae4e24c19d0f4cd8bebceac60828530e579977d70289a"
+checksum = "104ca17f56cde00a10207169697dfe9c6810db339d52fb352707e64875b30a44"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-tower"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d517ac2476efc1820228c2fdfdcb17d3bea8695558bd67584a62a47c12b41918"
+checksum = "4f38231d3f5dac9ac7976f44e12803add1385119ffca9e5f050d8e980733d164"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-protocol-test"
-version = "0.54.3"
+version = "0.54.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51425d035725e1f029fb9ed76f190c939c99355a955308d3c5976578b5ffbbca"
+checksum = "d4d1c9bcb35ce11055ec128dab2c66a7ed47e2dfff99883e32c21a1ab6d6bee6"
 dependencies = [
  "assert-json-diff",
  "http",
@@ -2307,7 +2307,10 @@ dependencies = [
  "aws-config",
  "aws-credential-types",
  "aws-sdk-s3",
+ "aws-smithy-client",
  "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-types",
  "aws-smithy-types-convert",
  "aws-types",
  "byte-unit",
@@ -2333,6 +2336,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower",
  "tracing",
  "url",
  "vergen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2300,7 +2300,7 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "ssstar"
-version = "0.4.3-dev"
+version = "0.4.2-dev"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2340,7 +2340,7 @@ dependencies = [
 
 [[package]]
 name = "ssstar-cli"
-version = "0.4.3-dev"
+version = "0.4.2-dev"
 dependencies = [
  "byte-unit",
  "clap",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "ssstar-testing"
-version = "0.4.3-dev"
+version = "0.4.2-dev"
 dependencies = [
  "again",
  "aws-config",

--- a/ssstar-cli/Cargo.toml
+++ b/ssstar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssstar-cli"
-version = "0.4.2-dev"
+version = "0.4.2"
 edition = "2021"
 authors = ["Adam Nelson <adam@elastio.com>"]
 description = """
@@ -27,7 +27,7 @@ path = "src/main.rs"
 name = "ssstar"
 
 [dependencies]
-ssstar = {version = "0.4.2-dev", path = "../ssstar", features = ["clap"] }
+ssstar = {version = "0.4.2", path = "../ssstar", features = ["clap"] }
 clap = { version = "4.1.6", features = ["derive","wrap_help"] }
 url = "2.3.0"
 byte-unit = "4.0.14"

--- a/ssstar-cli/Cargo.toml
+++ b/ssstar-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssstar-cli"
-version = "0.4.2"
+version = "0.4.3-dev"
 edition = "2021"
 authors = ["Adam Nelson <adam@elastio.com>"]
 description = """
@@ -27,7 +27,7 @@ path = "src/main.rs"
 name = "ssstar"
 
 [dependencies]
-ssstar = {version = "0.4.2", path = "../ssstar", features = ["clap"] }
+ssstar = {version = "0.4.3-dev", path = "../ssstar", features = ["clap"] }
 clap = { version = "4.1.6", features = ["derive","wrap_help"] }
 url = "2.3.0"
 byte-unit = "4.0.14"

--- a/ssstar-testing/Cargo.toml
+++ b/ssstar-testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssstar-testing"
-version = "0.4.2"
+version = "0.4.3-dev"
 edition = "2021"
 authors = ["Adam Nelson <adam@elastio.com>"]
 description = """

--- a/ssstar-testing/Cargo.toml
+++ b/ssstar-testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssstar-testing"
-version = "0.4.2-dev"
+version = "0.4.2"
 edition = "2021"
 authors = ["Adam Nelson <adam@elastio.com>"]
 description = """

--- a/ssstar/Cargo.toml
+++ b/ssstar/Cargo.toml
@@ -35,7 +35,10 @@ async-trait = "0.1.64"
 aws-config = "0.54.1"
 aws-credential-types = { version = "0.54.1", features = ["hardcoded-credentials"] }
 aws-sdk-s3 = { version = "0.24.0", features = ["rt-tokio"] }
+aws-smithy-client = "0.54.4"
 aws-smithy-http = "0.54.4"
+aws-smithy-http-tower = "0.54.4"
+aws-smithy-types = "0.54.4"
 aws-smithy-types-convert = { version = "0.54.3", features = ["convert-chrono"] }
 aws-types = { version = "0.54.1", features = [] }
 byte-unit = { version = "4" }
@@ -53,6 +56,7 @@ tar = "0.4.38"
 tokio = { version = "1.25.0", features = ["full"] }
 tokio-stream = "0.1.12"
 tokio-util = { version = "0.7.7", features = ["io", "io-util"] }
+tower = "0.4.13"
 tracing = "0.1.36"
 url = "2.3.0"
 

--- a/ssstar/Cargo.toml
+++ b/ssstar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssstar"
-version = "0.4.2"
+version = "0.4.3-dev"
 edition = "2021"
 authors = ["Adam Nelson <adam@elastio.com>"]
 description = """
@@ -57,7 +57,7 @@ tracing = "0.1.36"
 url = "2.3.0"
 
 [dev-dependencies]
-ssstar-testing = { version = "0.4.2", path = "../ssstar-testing" }
+ssstar-testing = { version = "0.4.3-dev", path = "../ssstar-testing" }
 color-eyre = "0.6.2"
 rand = "0.8.5"
 strum = { version = "0.24.1", features = ["derive"] }

--- a/ssstar/Cargo.toml
+++ b/ssstar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssstar"
-version = "0.4.2-dev"
+version = "0.4.2"
 edition = "2021"
 authors = ["Adam Nelson <adam@elastio.com>"]
 description = """
@@ -57,7 +57,7 @@ tracing = "0.1.36"
 url = "2.3.0"
 
 [dev-dependencies]
-ssstar-testing = { version = "0.4.2-dev", path = "../ssstar-testing" }
+ssstar-testing = { version = "0.4.2", path = "../ssstar-testing" }
 color-eyre = "0.6.2"
 rand = "0.8.5"
 strum = { version = "0.24.1", features = ["derive"] }

--- a/ssstar/src/config.rs
+++ b/ssstar/src/config.rs
@@ -91,6 +91,12 @@ pub struct Config {
     /// In case of multipart transfers, each chunk counts as a separate task.
     #[cfg_attr(feature = "clap", clap(long, default_value = "1000", global = true))]
     pub max_queue_size: usize,
+
+    /// The user agent to send to the S3 API endpoint.
+    ///
+    /// This defaults to something provided by the AWS SDK for Rust.
+    #[cfg_attr(feature = "clap", clap(long, global = true))]
+    pub user_agent: Option<String>,
 }
 
 impl Default for Config {
@@ -108,6 +114,7 @@ impl Default for Config {
             multipart_threshold: byte_unit::Byte::from_bytes(8 * 1024 * 1024),
             max_concurrent_requests: 10,
             max_queue_size: 1000,
+            user_agent: None,
         }
     }
 }


### PR DESCRIPTION
We need to be able to send a custom user agent string to the S3 APIs as
part of our commercial product (Elastio) which uses `ssstar` internally.
There's an open issue to add this functionality to the AWS SDK for Rust
(awslabs/aws-sdk-rust#146), but it's very old and clearly has not been
implemented.

Through trial and error, and guided by the implementation in another
open source code base (awslabs/amazon-qldb-shell#196) I was able to
cobble something together that works.  It's not pretty, and it involves
mostly duplicating the internal implementation of the
`Client::with_confg` function from the S3 SDK, however it will have to
do for now until official support is added to the SDK.

Part of (but doesn't yet close) #94
