### PR TITLE
Add ability to create empty archive

### DIFF
--- a/ssstar/src/create.rs
+++ b/ssstar/src/create.rs
@@ -194,6 +194,7 @@ impl CreateArchiveInput {
     ///
     /// This could be a long-running operation if a bucket or prefix is specified which contains
     /// hundreds of thousands or millions of objects.
+    #[instrument(err, skip(self))]
     async fn into_possible_input_objects(self) -> Result<Vec<InputObject>> {
         // Enumerating objects is an object storage implementation-specific operation
         let input_text = self.to_string();


### PR DESCRIPTION
<!-- Please explain the changes you made -->
There was added new flag `allow_empty` to `CreateArchiveJobBuilder`. An archive can be created without any objects and it won't fail in that cases.
<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/elastio/ssstar/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/elastio/ssstar/blob/main/CHANGELOG.md
-->
