### PR TITLE
feat(ssstar): add force_path_style config

### DIFF
--- a/ssstar/src/config.rs
+++ b/ssstar/src/config.rs
@@ -131,6 +131,10 @@ pub struct Config {
     /// This defaults to something provided by the AWS SDK for Rust.
     #[cfg_attr(feature = "clap", clap(long, global = true))]
     pub user_agent: Option<String>,
+
+    /// Force the client to use path-style addressing for buckets.
+    #[cfg_attr(feature = "clap", clap(long, global = true))]
+    pub force_path_style: bool,
 }
 
 impl Default for Config {
@@ -153,6 +157,7 @@ impl Default for Config {
             max_concurrent_requests: 10,
             max_queue_size: 1000,
             user_agent: None,
+            force_path_style: false,
         }
     }
 }

--- a/ssstar/src/objstore/s3.rs
+++ b/ssstar/src/objstore/s3.rs
@@ -1526,6 +1526,10 @@ async fn make_s3_client(
                 .map_err(|err| crate::S3TarError::HeaderValueConvertion { source: err })?,
         });
 
+    if config.force_path_style {
+        s3_config_builder = s3_config_builder.force_path_style(true);
+    }
+
     if let Some(s3_endpoint) = &config.s3_endpoint {
         s3_config_builder = s3_config_builder.endpoint_url(s3_endpoint.to_string());
     }


### PR DESCRIPTION
Introduces a new force_path_style configuration that maps to https://docs.rs/aws-sdk-s3/latest/aws_sdk_s3/config/struct.Builder.html#method.force_path_style

I realized I need this because I'm trying to connect to a minio server using `http://host.docker.internal` and ran into https://github.com/awslabs/aws-sdk-rust/issues/1138
