### PR TITLE
chore: fix Rust 1.86 type inference and update to Rust 1.86

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@1.86.0
         with:
           components: rustfmt
       - uses: Swatinem/rust-cache@v2
@@ -57,7 +57,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@1.86.0
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
@@ -84,7 +84,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@1.86.0
       - uses: Swatinem/rust-cache@v2
       - name: Cache the minio binary
         id: cache-minio
@@ -149,7 +149,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@1.86.0
         with:
           targets: x86_64-unknown-linux-musl
       - name: Install MUSL deps
@@ -174,7 +174,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@1.86.0
       - uses: Swatinem/rust-cache@v2
       - name: Check documentation
         env:

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@1.86.0
       - uses: Swatinem/rust-cache@v2
       - name: Publish ssstar-testing
         uses: actions-rs/cargo@v1

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@1.86.0
         with:
           targets: ${{ matrix.job.target }}
       - uses: Swatinem/rust-cache@v2

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,4 +4,4 @@
 # in CI does not and probably never will honor `rust-toolchain`.  So if you ever update this Rust version, make sure
 # that you also modify the GHA workflows in `.github/workflows/` to use the same version, or some confusing artifacts
 # will likely present themselves.
-channel = "1.85.0"
+channel = "1.86.0"

--- a/ssstar/src/extract.rs
+++ b/ssstar/src/extract.rs
@@ -291,7 +291,7 @@ impl ExtractFilter {
     /// be `foo/bar/baz`
     fn matches(&self, path: &Path) -> bool {
         match self {
-            Self::Object { key } => path.to_string_lossy() == key.as_ref(),
+            Self::Object { key } => path.to_string_lossy() == key.as_str(),
             Self::Prefix { prefix } => path.to_string_lossy().starts_with(&**prefix),
             Self::Glob { pattern } => {
                 // To make sure the glob matching behaviors like it does in unix shells, require


### PR DESCRIPTION
We're using Rust 1.86 and one compile error showed up for ssstar.

```
    Checking ssstar v0.7.3 (/media/workspace/src/cn/ssstar/ssstar)
error[E0283]: type annotations needed
   --> ssstar/src/extract.rs:294:60
    |
294 |             Self::Object { key } => path.to_string_lossy() == key.as_ref(),
    |                                                            ^^ cannot infer type for reference `&_`
    |
    = note: multiple `impl`s satisfying `Cow<'_, str>: PartialEq<&_>` found in the `alloc` crate:
            - impl<'a, 'b> PartialEq<&'b str> for Cow<'a, str>;
            - impl<'a> PartialEq<&'a ByteStr> for Cow<'a, str>;

error[E0283]: type annotations needed
   --> ssstar/src/extract.rs:294:67
    |
294 |             Self::Object { key } => path.to_string_lossy() == key.as_ref(),
    |                                                                   ^^^^^^
    |
    = note: multiple `impl`s satisfying `std::string::String: AsRef<_>` found in the following crates: `alloc`, `std`:
            - impl AsRef<Path> for std::string::String;
            - impl AsRef<[u8]> for std::string::String;
            - impl AsRef<std::ffi::OsStr> for std::string::String;
            - impl AsRef<str> for std::string::String;
help: try using a fully qualified path to specify the expected types
    |
294 -             Self::Object { key } => path.to_string_lossy() == key.as_ref(),
294 +             Self::Object { key } => path.to_string_lossy() == <std::string::String as AsRef<T>>::as_ref(key),
    |

For more information about this error, try `rustc --explain E0283`.
error: could not compile `ssstar` (lib) due to 2 previous errors
```

I think this is a regression in the compiler, so I submitted a report https://github.com/rust-lang/rust/issues/139542
But eventually when `ByteStr` stabilizes this problem may come back. So using `as_str()` should help with this.